### PR TITLE
Don't attempt to marshal the continuation back to the original context captured

### DIFF
--- a/src/Seq.Api/Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Api/Client/SeqApiClient.cs
@@ -77,7 +77,7 @@ namespace Seq.Api.Client
         {
             var linkUri = ResolveLink(entity, link, parameters);
             var request = new HttpRequestMessage(HttpMethod.Post, linkUri) { Content = MakeJsonContent(content) };
-            var stream = await HttpSendAsync(request);
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
             new StreamReader(stream).ReadToEnd();
         }
 
@@ -85,7 +85,7 @@ namespace Seq.Api.Client
         {
             var linkUri = ResolveLink(entity, link, parameters);
             var request = new HttpRequestMessage(HttpMethod.Post, linkUri) { Content = MakeJsonContent(content) };
-            var stream = await HttpSendAsync(request);
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
             return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
         }
 
@@ -93,7 +93,7 @@ namespace Seq.Api.Client
         {
             var linkUri = ResolveLink(entity, link, parameters);
             var request = new HttpRequestMessage(HttpMethod.Put, linkUri) { Content = MakeJsonContent(content) };
-            var stream = await HttpSendAsync(request);
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
             new StreamReader(stream).ReadToEnd();
         }
 
@@ -101,14 +101,14 @@ namespace Seq.Api.Client
         {
             var linkUri = ResolveLink(entity, link, parameters);
             var request = new HttpRequestMessage(HttpMethod.Delete, linkUri) { Content = MakeJsonContent(content) };
-            var stream = await HttpSendAsync(request);
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
             new StreamReader(stream).ReadToEnd();
         }
 
         async Task<T> HttpGetAsync<T>(string url)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            var stream = await HttpSendAsync(request);
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
             return _serializer.Deserialize<T>(new JsonTextReader(new StreamReader(stream)));
         }
 
@@ -118,9 +118,9 @@ namespace Seq.Api.Client
                 request.Headers.Add("X-Seq-ApiKey", _apiKey);
 
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV2MediaType));
-            
-            var response = await _httpClient.SendAsync(request);                
-            var stream = await response.Content.ReadAsStreamAsync();
+
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             
             if (response.IsSuccessStatusCode)
                 return stream;

--- a/src/Seq.Api/Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -15,32 +15,32 @@ namespace Seq.Api.ResourceGroups
         public async Task<ApiKeyEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<ApiKeyEntity>("Item", new Dictionary<string, object> {{"id", id}});
+            return await GroupGetAsync<ApiKeyEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<ApiKeyEntity>> ListAsync()
         {
-            return await GroupListAsync<ApiKeyEntity>("Items");
+            return await GroupListAsync<ApiKeyEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<ApiKeyEntity> TemplateAsync()
         {
-            return await GroupGetAsync<ApiKeyEntity>("Template");
+            return await GroupGetAsync<ApiKeyEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<ApiKeyEntity> AddAsync(ApiKeyEntity entity)
         {
-            return await Client.PostAsync<ApiKeyEntity, ApiKeyEntity>(entity, "Create", entity);
+            return await Client.PostAsync<ApiKeyEntity, ApiKeyEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(ApiKeyEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(ApiKeyEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/ApiResourceGroup.cs
@@ -27,38 +27,38 @@ namespace Seq.Api.ResourceGroups
 
         protected async Task<TEntity> GroupGetAsync<TEntity>(string link, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            return await Client.GetAsync<TEntity>(group, link, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            return await Client.GetAsync<TEntity>(group, link, parameters).ConfigureAwait(false);
         }
 
         protected async Task<List<TEntity>> GroupListAsync<TEntity>(string link, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            return await Client.ListAsync<TEntity>(group, link, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            return await Client.ListAsync<TEntity>(group, link, parameters).ConfigureAwait(false);
         }
 
         protected async Task GroupPostAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            await Client.PostAsync(group, link, content, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            await Client.PostAsync(group, link, content, parameters).ConfigureAwait(false);
         }
 
         protected async Task<TResponse> GroupPostAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters).ConfigureAwait(false);
         }
 
         protected async Task GroupPutAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            await Client.PutAsync(group, link, content, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            await Client.PutAsync(group, link, content, parameters).ConfigureAwait(false);
         }
 
         protected async Task GroupDeleteAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null)
         {
-            var group = await LoadGroupAsync();
-            await Client.DeleteAsync(group, link, content, parameters);
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            await Client.DeleteAsync(group, link, content, parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -15,33 +15,33 @@ namespace Seq.Api.ResourceGroups
         public async Task<AppInstanceEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<AppInstanceEntity>("Item", new Dictionary<string, object> {{"id", id}});
+            return await GroupGetAsync<AppInstanceEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<AppInstanceEntity>> ListAsync()
         {
-            return await GroupListAsync<AppInstanceEntity>("Items");
+            return await GroupListAsync<AppInstanceEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<AppInstanceEntity> TemplateAsync(string appId)
         {
             if (appId == null) throw new ArgumentNullException("appId");
-            return await GroupGetAsync<AppInstanceEntity>("Template", new Dictionary<string, object> { { "appId", appId } });
+            return await GroupGetAsync<AppInstanceEntity>("Template", new Dictionary<string, object> { { "appId", appId } }).ConfigureAwait(false);
         }
 
         public async Task<AppInstanceEntity> AddAsync(AppInstanceEntity entity, bool runOnExisting = false)
         {
-            return await Client.PostAsync<AppInstanceEntity, AppInstanceEntity>(entity, "Create", entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } });
+            return await Client.PostAsync<AppInstanceEntity, AppInstanceEntity>(entity, "Create", entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } }).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(AppInstanceEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(AppInstanceEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/AppsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/AppsResourceGroup.cs
@@ -15,32 +15,32 @@ namespace Seq.Api.ResourceGroups
         public async Task<AppEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<AppEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<AppEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<AppEntity>> ListAsync()
         {
-            return await GroupListAsync<AppEntity>("Items");
+            return await GroupListAsync<AppEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<AppEntity> TemplateAsync()
         {
-            return await GroupGetAsync<AppEntity>("Template");
+            return await GroupGetAsync<AppEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<AppEntity> AddAsync(AppEntity entity)
         {
-            return await Client.PostAsync<AppEntity, AppEntity>(entity, "Create", entity);
+            return await Client.PostAsync<AppEntity, AppEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(AppEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(AppEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task<AppEntity> InstallPackageAsync(string feedId, string packageId, string version = null)
@@ -49,7 +49,7 @@ namespace Seq.Api.ResourceGroups
             if (packageId == null) throw new ArgumentNullException("packageId");
             var parameters = new Dictionary<string, object>{{ "feedId", feedId}, {"packageId", packageId}};
             if (version != null) parameters.Add("version", version);
-            return await GroupPostAsync<object, AppEntity>("InstallPackage", new object(), parameters);
+            return await GroupPostAsync<object, AppEntity>("InstallPackage", new object(), parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/EventsResourceGroup.cs
@@ -18,7 +18,7 @@ namespace Seq.Api.ResourceGroups
         public async Task<EventEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<EventEntity>("Item", new Dictionary<string, object> {{"id", id}});
+            return await GroupGetAsync<EventEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Seq.Api.ResourceGroups
 
             while (true)
             {
-                var resultSet = await GroupGetAsync<ResultSetPart>("InSignal", parameters);
+                var resultSet = await GroupGetAsync<ResultSetPart>("InSignal", parameters).ConfigureAwait(false);
                 chunks.Add(resultSet.Events);
                 remaining -= resultSet.Events.Count;
 
@@ -108,7 +108,7 @@ namespace Seq.Api.ResourceGroups
             if (shortCircuitAfter != null) { parameters.Add("shortCircuitAfter", shortCircuitAfter.Value); }
 
             var body = signal ?? new SignalEntity();
-            return await GroupPostAsync<SignalEntity, ResultSetPart>("InSignal", body, parameters);
+            return await GroupPostAsync<SignalEntity, ResultSetPart>("InSignal", body, parameters).ConfigureAwait(false);
         }
 
         public async Task<ResultSetPart> InSignalAsync(
@@ -137,7 +137,7 @@ namespace Seq.Api.ResourceGroups
             if (toDateUtc != null) { parameters.Add("toDateUtc", toDateUtc.Value); }
             if (shortCircuitAfter != null) { parameters.Add("shortCircuitAfter", shortCircuitAfter.Value); }
 
-            return await GroupGetAsync<ResultSetPart>("InSignal", parameters);
+            return await GroupGetAsync<ResultSetPart>("InSignal", parameters).ConfigureAwait(false);
         }
 
         public async Task<ResultSetPart> DeleteInSignalAsync(
@@ -154,7 +154,7 @@ namespace Seq.Api.ResourceGroups
             if (toDateUtc != null) { parameters.Add("toDateUtc", toDateUtc.Value); }
 
             var body = signal ?? new SignalEntity();
-            return await GroupPostAsync<SignalEntity, ResultSetPart>("DeleteInSignal", body, parameters);
+            return await GroupPostAsync<SignalEntity, ResultSetPart>("DeleteInSignal", body, parameters).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/FeedsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/FeedsResourceGroup.cs
@@ -15,32 +15,32 @@ namespace Seq.Api.ResourceGroups
         public async Task<NuGetFeedEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<NuGetFeedEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<NuGetFeedEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<NuGetFeedEntity>> ListAsync()
         {
-            return await GroupListAsync<NuGetFeedEntity>("Items");
+            return await GroupListAsync<NuGetFeedEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<NuGetFeedEntity> TemplateAsync()
         {
-            return await GroupGetAsync<NuGetFeedEntity>("Template");
+            return await GroupGetAsync<NuGetFeedEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<NuGetFeedEntity> AddAsync(NuGetFeedEntity entity)
         {
-            return await Client.PostAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, "Create", entity);
+            return await Client.PostAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(NuGetFeedEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(NuGetFeedEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/LicensesResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/LicensesResourceGroup.cs
@@ -16,27 +16,27 @@ namespace Seq.Api.ResourceGroups
         public async Task<LicenseEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<LicenseEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<LicenseEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<LicenseEntity> FindCurrentAsync()
         {
-            return await GroupGetAsync<LicenseEntity>("Current");
+            return await GroupGetAsync<LicenseEntity>("Current").ConfigureAwait(false);
         }
 
         public async Task<List<LicenseEntity>> ListAsync()
         {
-            return await GroupListAsync<LicenseEntity>("Items");
+            return await GroupListAsync<LicenseEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(LicenseEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task DowngradeAsync()
         {
-            await GroupPostAsync("Downgrade", new object());
+            await GroupPostAsync("Downgrade", new object()).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/MetricsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/MetricsResourceGroup.cs
@@ -12,7 +12,7 @@ namespace Seq.Api.ResourceGroups
 
         public async Task<MetricsEntity> FindCurrentAsync()
         {
-            return await GroupGetAsync<MetricsEntity>("Current");
+            return await GroupGetAsync<MetricsEntity>("Current").ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/PinsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/PinsResourceGroup.cs
@@ -26,7 +26,7 @@ namespace Seq.Api.ResourceGroups
                 {"renderEvent", renderEvent},
                 {"includeUser", includeUser}
             };
-            return await GroupGetAsync<PinEntity>("Item", parameters);
+            return await GroupGetAsync<PinEntity>("Item", parameters).ConfigureAwait(false);
         }
 
         public async Task<List<PinEntity>> ListAsync(
@@ -41,27 +41,27 @@ namespace Seq.Api.ResourceGroups
                 {"includeUser", includeUser}
             };
 
-            return await GroupListAsync<PinEntity>("Items", parameters);
+            return await GroupListAsync<PinEntity>("Items", parameters).ConfigureAwait(false);
         }
 
         public async Task<PinEntity> TemplateAsync()
         {
-            return await GroupGetAsync<PinEntity>("Template");
+            return await GroupGetAsync<PinEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<PinEntity> AddAsync(PinEntity entity)
         {
-            return await Client.PostAsync<PinEntity, PinEntity>(entity, "Create", entity);
+            return await Client.PostAsync<PinEntity, PinEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(PinEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(PinEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
@@ -15,32 +15,32 @@ namespace Seq.Api.ResourceGroups
         public async Task<RetentionPolicyEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<RetentionPolicyEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<RetentionPolicyEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<RetentionPolicyEntity>> ListAsync()
         {
-            return await GroupListAsync<RetentionPolicyEntity>("Items");
+            return await GroupListAsync<RetentionPolicyEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<RetentionPolicyEntity> TemplateAsync()
         {
-            return await GroupGetAsync<RetentionPolicyEntity>("Template");
+            return await GroupGetAsync<RetentionPolicyEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<RetentionPolicyEntity> AddAsync(RetentionPolicyEntity entity)
         {
-            return await Client.PostAsync<RetentionPolicyEntity, RetentionPolicyEntity>(entity, "Create", entity);
+            return await Client.PostAsync<RetentionPolicyEntity, RetentionPolicyEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(RetentionPolicyEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(RetentionPolicyEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/SettingsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/SettingsResourceGroup.cs
@@ -15,37 +15,37 @@ namespace Seq.Api.ResourceGroups
         public async Task<SettingEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<SettingEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<SettingEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<SettingEntity> FindNamedAsync(SettingName name)
         {
-            return await GroupGetAsync<SettingEntity>(name.ToString());
+            return await GroupGetAsync<SettingEntity>(name.ToString()).ConfigureAwait(false);
         }
 
         public async Task<List<SettingEntity>> ListAsync()
         {
-            return await GroupListAsync<SettingEntity>("Items");
+            return await GroupListAsync<SettingEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<SettingEntity> TemplateAsync()
         {
-            return await GroupGetAsync<SettingEntity>("Template");
+            return await GroupGetAsync<SettingEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<SettingEntity> AddAsync(SettingEntity entity)
         {
-            return await Client.PostAsync<SettingEntity, SettingEntity>(entity, "Create", entity);
+            return await Client.PostAsync<SettingEntity, SettingEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(SettingEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(SettingEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/SignalsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/SignalsResourceGroup.cs
@@ -15,32 +15,32 @@ namespace Seq.Api.ResourceGroups
         public async Task<SignalEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<SignalEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<SignalEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<SignalEntity>> ListAsync()
         {
-            return await GroupListAsync<SignalEntity>("Items");
+            return await GroupListAsync<SignalEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<SignalEntity> TemplateAsync()
         {
-            return await GroupGetAsync<SignalEntity>("Template");
+            return await GroupGetAsync<SignalEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<SignalEntity> AddAsync(SignalEntity entity)
         {
-            return await Client.PostAsync<SignalEntity, SignalEntity>(entity, "Create", entity);
+            return await Client.PostAsync<SignalEntity, SignalEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(SignalEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(SignalEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/UpdatesResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/UpdatesResourceGroup.cs
@@ -13,7 +13,7 @@ namespace Seq.Api.ResourceGroups
 
         public async Task<List<AvailableUpdateEntity>> ListAsync()
         {
-            return await GroupListAsync<AvailableUpdateEntity>("Items");
+            return await GroupListAsync<AvailableUpdateEntity>("Items").ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/UsersResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/UsersResourceGroup.cs
@@ -15,37 +15,37 @@ namespace Seq.Api.ResourceGroups
         public async Task<UserEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<UserEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<UserEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<UserEntity> FindCurrentAsync()
         {
-            return await GroupGetAsync<UserEntity>("Current");
+            return await GroupGetAsync<UserEntity>("Current").ConfigureAwait(false);
         }
 
         public async Task<List<UserEntity>> ListAsync()
         {
-            return await GroupListAsync<UserEntity>("Items");
+            return await GroupListAsync<UserEntity>("Items").ConfigureAwait(false);
         }
 
         public async Task<UserEntity> TemplateAsync()
         {
-            return await GroupGetAsync<UserEntity>("Template");
+            return await GroupGetAsync<UserEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<UserEntity> AddAsync(UserEntity entity)
         {
-            return await Client.PostAsync<UserEntity, UserEntity>(entity, "Create", entity);
+            return await Client.PostAsync<UserEntity, UserEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(UserEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(UserEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task<UserEntity> LoginAsync(string username, string password)
@@ -53,12 +53,12 @@ namespace Seq.Api.ResourceGroups
             if (username == null) throw new ArgumentNullException("username");
             if (password == null) throw new ArgumentNullException("password");
             var credentials = new CredentialsPart {Username = username, Password = password};
-            return await GroupPostAsync<CredentialsPart, UserEntity>("Login", credentials);
+            return await GroupPostAsync<CredentialsPart, UserEntity>("Login", credentials).ConfigureAwait(false);
         }
 
         public async Task LogoutAsync()
         {
-            await GroupPostAsync("Logout", new object());
+            await GroupPostAsync("Logout", new object()).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/WatchesResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/WatchesResourceGroup.cs
@@ -15,7 +15,7 @@ namespace Seq.Api.ResourceGroups
         public async Task<WatchEntity> FindAsync(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
-            return await GroupGetAsync<WatchEntity>("Item", new Dictionary<string, object> { { "id", id } });
+            return await GroupGetAsync<WatchEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
         }
 
         public async Task<List<WatchEntity>> ListAsync(string ownerId = null)
@@ -23,27 +23,27 @@ namespace Seq.Api.ResourceGroups
             var parameters = new Dictionary<string, object>();
             if (ownerId != null)
                 parameters.Add("ownerId", ownerId);
-            return await GroupListAsync<WatchEntity>("Items", parameters);
+            return await GroupListAsync<WatchEntity>("Items", parameters).ConfigureAwait(false);
         }
 
         public async Task<WatchEntity> TemplateAsync()
         {
-            return await GroupGetAsync<WatchEntity>("Template");
+            return await GroupGetAsync<WatchEntity>("Template").ConfigureAwait(false);
         }
 
         public async Task<WatchEntity> AddAsync(WatchEntity entity)
         {
-            return await Client.PostAsync<WatchEntity, WatchEntity>(entity, "Create", entity);
+            return await Client.PostAsync<WatchEntity, WatchEntity>(entity, "Create", entity).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(WatchEntity entity)
         {
-            await Client.DeleteAsync(entity, "Self", entity);
+            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(WatchEntity entity)
         {
-            await Client.PutAsync(entity, "Self", entity);
+            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Api/SeqConnection.cs
+++ b/src/Seq.Api/Api/SeqConnection.cs
@@ -100,12 +100,12 @@ namespace Seq.Api
 
         public async Task<ResourceGroup> LoadResourceGroupAsync(string name)
         {
-            return await _resourceGroups.GetOrAdd(name, ResourceGroupFactory);
+            return await _resourceGroups.GetOrAdd(name, ResourceGroupFactory).ConfigureAwait(false);
         }
 
         private async Task<ResourceGroup> ResourceGroupFactory(string name)
         {
-            return await _client.GetAsync<ResourceGroup>(await _root.Value, name + "Resources");
+            return await _client.GetAsync<ResourceGroup>(await _root.Value, name + "Resources").ConfigureAwait(false);
         }
 
         public SeqApiClient Client { get { return _client; } }


### PR DESCRIPTION
Hi Nick,

This commit updates Seq.Api to follow best practice of calling ConfigureAwait(false) for non-UI libraries/non-top level code.  At the top level code, like SeqTail, a developer would NOT specify ConfigureAwait(false) and the continuation of the async method would be marshaled back to the synchronization context captured before the await.   

Here's some references:
[Async/Await - Best Practices in Asynchronous Programming](https://msdn.microsoft.com/en-us/magazine/jj991977.aspx)
[Preventing the Deadlock](http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html)
[Stackoverflow](http://stackoverflow.com/a/27851460/5167537)