### PR TITLE
Oops - typo in dev version prefix

### DIFF
--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>2020.3.0</VersionPrefix>
+    <VersionPrefix>2021.3.0</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Typo when manually merging the earlier changes, which breaks the Seq MSI (file version regression).