### PR TITLE
Earlier 2025.2 builds produce `ws://` absolute WebSocket URIs, fix scheme normalization

### DIFF
--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -528,8 +528,10 @@ public sealed class SeqApiClient : IDisposable
             absoluteUnknownScheme = new UriBuilder(combined);
         }
 
-        absoluteUnknownScheme.Scheme = absoluteUnknownScheme.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ? "ws" : "wss";
-
+        absoluteUnknownScheme.Scheme = absoluteUnknownScheme.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
+                                       absoluteUnknownScheme.Scheme.Equals("ws", StringComparison.OrdinalIgnoreCase) ? 
+            "ws" : "wss";
+        
         return absoluteUnknownScheme.ToString();
     }
 


### PR DESCRIPTION
Unfortunately our integration tests missed this one, which showed up _minutes_ after publishing 2025.2.1 of this library. We'll have to unlist that one: 2025.2.2 it is!