### PR TITLE
`Data.TryQueryAsync()`, remaining metrics updates

### DIFF
--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -191,7 +191,7 @@ public sealed class SeqApiClient : IDisposable
         return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
     }
     
-    // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+    // Throws on 5xx errors; callers are expected to derive 400 error information from the response stream.
     internal async Task<TResponse> TryPostAsync<TEntity, TResponse>(ILinked entity, string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
     {
         var linkUri = ResolveLink(entity, link, parameters);
@@ -461,18 +461,18 @@ public sealed class SeqApiClient : IDisposable
             ).ConfigureAwait(false);
     }
 
-    // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+    // Throws on 5xx errors; callers are expected to derive 400 error information from the response stream.
     async Task<Stream> HttpTrySendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
     {
-        return await HttpSendAsyncCore(request, throwOn4xx: false, cancellationToken);
+        return await HttpSendAsyncCore(request, throwOn400: false, cancellationToken);
     }
 
     async Task<Stream> HttpSendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
     {
-        return await HttpSendAsyncCore(request, throwOn4xx: true, cancellationToken);
+        return await HttpSendAsyncCore(request, throwOn400: true, cancellationToken);
     }
 
-    async Task<Stream> HttpSendAsyncCore(HttpRequestMessage request, bool throwOn4xx, CancellationToken cancellationToken)
+    async Task<Stream> HttpSendAsyncCore(HttpRequestMessage request, bool throwOn400, CancellationToken cancellationToken)
     {
         var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync(
@@ -481,7 +481,7 @@ public sealed class SeqApiClient : IDisposable
 #endif
             ).ConfigureAwait(false);
 
-        if (response.IsSuccessStatusCode || (!throwOn4xx && (int)response.StatusCode >= 400 && (int)response.StatusCode < 500))
+        if (response.IsSuccessStatusCode || (!throwOn400 && response.StatusCode == HttpStatusCode.BadRequest))
         {
             return stream;
         }

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -191,7 +191,7 @@ public sealed class SeqApiClient : IDisposable
         return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
     }
     
-    // Throws on 5xx errors; callers are expected to derive 400 error information from the response stream.
+    // Callers are expected to derive 400 error information from the response stream. All other result status codes throw.
     internal async Task<TResponse> TryPostAsync<TEntity, TResponse>(ILinked entity, string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
     {
         var linkUri = ResolveLink(entity, link, parameters);

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -191,6 +191,14 @@ public sealed class SeqApiClient : IDisposable
         return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
     }
     
+    // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+    internal async Task<TResponse> TryPostAsync<TEntity, TResponse>(ILinked entity, string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
+    {
+        var linkUri = ResolveLink(entity, link, parameters);
+        var request = new HttpRequestMessage(HttpMethod.Post, linkUri) { Content = MakeJsonContent(content) };
+        var stream = await HttpTrySendAsync(request, cancellationToken).ConfigureAwait(false);
+        return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
+    }
     /// <summary>
     /// Issue a <c>POST</c> request accepting a serialized <typeparamref name="TEntity"/> and returning a string by following <paramref name="link"/> from <paramref name="entity"/>.
     /// </summary>
@@ -452,8 +460,19 @@ public sealed class SeqApiClient : IDisposable
 #endif
             ).ConfigureAwait(false);
     }
-    
+
+    // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+    async Task<Stream> HttpTrySendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    {
+        return await HttpSendAsyncCore(request, throwOn4xx: false, cancellationToken);
+    }
+
     async Task<Stream> HttpSendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+    {
+        return await HttpSendAsyncCore(request, throwOn4xx: true, cancellationToken);
+    }
+
+    async Task<Stream> HttpSendAsyncCore(HttpRequestMessage request, bool throwOn4xx, CancellationToken cancellationToken)
     {
         var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync(
@@ -462,7 +481,7 @@ public sealed class SeqApiClient : IDisposable
 #endif
             ).ConfigureAwait(false);
 
-        if (response.IsSuccessStatusCode)
+        if (response.IsSuccessStatusCode || (!throwOn4xx && (int)response.StatusCode >= 400 && (int)response.StatusCode < 500))
         {
             return stream;
         }

--- a/src/Seq.Api/Model/Alerting/AlertActivityPart.cs
+++ b/src/Seq.Api/Model/Alerting/AlertActivityPart.cs
@@ -38,14 +38,14 @@ namespace Seq.Api.Model.Alerting
         /// <summary>
         /// The most recent occurrences of the alert that triggered notifications.
         /// </summary>
-        public List<AlertOccurrencePart> RecentOccurrences { get; set; } = new List<AlertOccurrencePart>();
+        public List<AlertOccurrencePart> RecentOccurrences { get; set; } = new();
 
         /// <summary>
         /// Minimal metrics for the most recent occurrences of the alert that triggered notifications.
         /// The metrics in this list are a superset of <see cref="RecentOccurrences"/>.
         /// </summary>
         public List<AlertOccurrenceRangePart> RecentOccurrenceRanges { get; set; } =
-            new List<AlertOccurrenceRangePart>();
+            new();
 
         /// <summary>
         /// The number of times this alert has been triggered since its creation.

--- a/src/Seq.Api/Model/Alerting/AlertEntity.cs
+++ b/src/Seq.Api/Model/Alerting/AlertEntity.cs
@@ -52,10 +52,20 @@ namespace Seq.Api.Model.Alerting
         public bool IsDisabled { get; set; }
         
         /// <summary>
+        /// The source of the data for the query.
+        /// </summary>
+        public DataSource DataSource { get; set; } = DataSource.Stream;
+
+        /// <summary>
+        /// Lateral joins applied to the data source.
+        /// </summary>
+        public List<JoinPart> Joins { get; set; } = [];
+        
+        /// <summary>
         /// An optional <see cref="SignalExpressionPart"/> limiting the data source that triggers the alert.
         /// </summary>
         public SignalExpressionPart SignalExpression { get; set; }
-
+        
         /// <summary>
         /// An optional <c>where</c> clause limiting the data source that triggers the alert.
         /// </summary>
@@ -75,7 +85,7 @@ namespace Seq.Api.Model.Alerting
         /// <summary>
         /// The individual measurements that will be tested by the alert condition.
         /// </summary>
-        public List<ColumnPart> Select { get; set; } = new List<ColumnPart>();
+        public List<ColumnPart> Select { get; set; } = [];
         
         /// <summary>
         /// The alert condition. This is a <c>having</c> clause over the grouped results

--- a/src/Seq.Api/Model/Alerting/AlertOccurrencePart.cs
+++ b/src/Seq.Api/Model/Alerting/AlertOccurrencePart.cs
@@ -28,6 +28,6 @@ namespace Seq.Api.Model.Alerting
         /// <summary>
         /// The <see cref="NotificationChannelPart">NotificationChannelParts</see> that were alerted.
         /// </summary>
-        public List<AlertNotificationPart> Notifications { get; set; } = new List<AlertNotificationPart>();
+        public List<AlertNotificationPart> Notifications { get; set; } = new();
     }
 }

--- a/src/Seq.Api/Model/Alerting/NotificationChannelPart.cs
+++ b/src/Seq.Api/Model/Alerting/NotificationChannelPart.cs
@@ -58,6 +58,6 @@ namespace Seq.Api.Model.Alerting
         /// by the alert.
         /// </summary>
         public Dictionary<string, string> NotificationAppSettingOverrides { get; set; } =
-            new Dictionary<string, string>();
+            new();
     }
 }

--- a/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
@@ -11,5 +11,12 @@ namespace Seq.Api.Model.AppInstances
         /// it being processed by the app.
         /// </summary>
         public int DispatchedEventsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of events per minute that failed to reach the app from Seq. Includes streamed events (if enabled),
+        /// manual invocations, and alert notifications. This value doesn't track events the app may have internally
+        /// failed to process.
+        /// </summary>
+        public int FailedEventsPerMinute { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/QueryResultPart.cs
+++ b/src/Seq.Api/Model/Data/QueryResultPart.cs
@@ -32,6 +32,7 @@ namespace Seq.Api.Model.Data
         /// <summary>
         /// The columns within the result set (at various levels of the hierarchy).
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string[] Columns { get; set; }
 
         /// <summary>
@@ -43,6 +44,7 @@ namespace Seq.Api.Model.Data
         /// <summary>
         /// Metadata for the time grouping column.
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ColumnMetadataPart TimeColumnMetadata { get; set; }
 
         /// <summary>

--- a/src/Seq.Api/Model/Metrics/MetricAggregationPreference.cs
+++ b/src/Seq.Api/Model/Metrics/MetricAggregationPreference.cs
@@ -6,27 +6,37 @@ namespace Seq.Api.Model.Metrics;
 public enum MetricAggregationPreference
 {
     /// <summary>
-    /// The <c>count()</c> aggregate function.
+    /// The total count of observed values.
     /// </summary>
-    Count,
-
+    Total,
+    
     /// <summary>
-    /// The <c>sum()</c> aggregate function.
+    /// The sum of all observed values.
     /// </summary>
     Sum,
     
     /// <summary>
-    /// The <c>min()</c> aggregate function.
+    /// The counts of values falling in each histogram bucket.
+    /// </summary>
+    BucketSum,
+    
+    /// <summary>
+    /// The smallest observed value.
     /// </summary>
     Min,
     
     /// <summary>
-    /// The <c>mean()</c> aggregate function.
+    /// The center observed value.
     /// </summary>
     Mean,
     
     /// <summary>
-    /// The <c>max()</c> aggregate function.
+    /// The largest observed value.
     /// </summary>
-    Max
+    Max,
+    
+    /// <summary>
+    /// The set of values greater than a percentage of all other observed values.
+    /// </summary>
+    Percentiles
 }

--- a/src/Seq.Api/Model/Queries/QueryEntity.cs
+++ b/src/Seq.Api/Model/Queries/QueryEntity.cs
@@ -14,19 +14,19 @@
 
 using Seq.Api.Model.Security;
 
-namespace Seq.Api.Model.SqlQueries
+namespace Seq.Api.Model.Queries
 {
     /// <summary>
-    /// A saved SQL-style query.
+    /// A saved query.
     /// </summary>
-    public class SqlQueryEntity : Entity
+    public class QueryEntity : Entity
     {
         /// <summary>
-        /// Construct a <see cref="SqlQueryEntity"/>.
+        /// Construct a <see cref="QueryEntity"/>.
         /// </summary>
-        public SqlQueryEntity()
+        public QueryEntity()
         {
-            Title = "New SQL Query";
+            Title = "New Query";
             Sql = "";
         }
 

--- a/src/Seq.Api/Model/Shared/JoinKind.cs
+++ b/src/Seq.Api/Model/Shared/JoinKind.cs
@@ -1,0 +1,31 @@
+// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Shared;
+
+/// <summary>
+/// A type of relational join. 
+/// </summary>
+public enum JoinKind
+{
+    /// <summary>
+    /// The unknown join kind.
+    /// </summary>
+    Unknown, 
+    
+    /// <summary>
+    /// A join type that joins each row to the output of a table function evaluated in the context of the row. 
+    /// </summary>
+    Lateral
+}

--- a/src/Seq.Api/Model/Shared/JoinPart.cs
+++ b/src/Seq.Api/Model/Shared/JoinPart.cs
@@ -1,0 +1,38 @@
+// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Shared;
+
+#nullable enable
+
+/// <summary>
+/// The lateral cross join part of a from clause.
+/// </summary>
+public class JoinPart
+{
+    /// <summary>
+    /// The type of relational join.
+    /// </summary>
+    public JoinKind Kind { get; set; }
+    
+    /// <summary>
+    /// The set function call used in the lateral join.
+    /// </summary>
+    public string? SetFunctionCall { get; set; }
+        
+    /// <summary>
+    /// The alias of the set function call. 
+    /// </summary>
+    public string? Alias { get; set; }
+}

--- a/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
@@ -16,7 +16,7 @@ using System.Collections.Generic;
 using Seq.Api.Model.Dashboarding;
 using Seq.Api.Model.Metrics;
 using Seq.Api.Model.Signals;
-using Seq.Api.Model.SqlQueries;
+using Seq.Api.Model.Queries;
 
 namespace Seq.Api.Model.Workspaces
 {
@@ -31,7 +31,7 @@ namespace Seq.Api.Model.Workspaces
         public List<string> SignalIds { get; set; } = [];
 
         /// <summary>
-        /// A list of <see cref="SqlQueryEntity"/> ids to include in the workspace.
+        /// A list of <see cref="QueryEntity"/> ids to include in the workspace.
         /// </summary>
         public List<string> QueryIds { get; set; } = [];
         

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -159,6 +159,13 @@ namespace Seq.Api.ResourceGroups
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
+        
+        // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+        internal async Task<TResponse> GroupTryPostAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
+        {
+            var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
+            return await Client.TryPostAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Update an entity.

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -160,7 +160,7 @@ namespace Seq.Api.ResourceGroups
             return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
         
-        // Throws on 5xx errors; callers are expected to derive 400 error information from the response stream.
+        // Callers are expected to derive 400 error information from the response stream. All other result status codes throw.
         internal async Task<TResponse> GroupTryPostAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -160,7 +160,7 @@ namespace Seq.Api.ResourceGroups
             return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
         
-        // Throws on 5xx errors; callers are expected to derive 4xx error information from the response stream.
+        // Throws on 5xx errors; callers are expected to derive 400 error information from the response stream.
         internal async Task<TResponse> GroupTryPostAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
@@ -33,7 +33,8 @@ namespace Seq.Api.ResourceGroups
         }
 
         /// <summary>
-        /// Execute an SQL query and retrieve the result set as a structured <see cref="QueryResultPart"/>.
+        /// Execute an SQL query and retrieve the result set as a structured <see cref="QueryResultPart"/>. For non-throwing
+        /// syntax error reporting, see <see cref="TryQueryAsync"/>.
         /// </summary>
         /// <param name="query">The query to execute.</param>
         /// <param name="rangeStartUtc">The earliest timestamp from which to include events in the query result.</param>
@@ -61,6 +62,37 @@ namespace Seq.Api.ResourceGroups
             return await GroupPostAsync<EvaluationContextPart, QueryResultPart>("Query", body, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Execute an SQL query and retrieve the result set as a structured <see cref="QueryResultPart"/>. This method
+        /// differs from <see cref="QueryAsync"/> by returning a result object with error information instead of throwing
+        /// when the query syntax is invalid.
+        /// </summary>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="rangeStartUtc">The earliest timestamp from which to include events in the query result.</param>
+        /// <param name="rangeEndUtc">The exclusive latest timestamp to which events are included in the query result. The default is the current time.</param>
+        /// <param name="signal">A signal expression over which the query will be executed.</param>
+        /// <param name="unsavedSignal">A constructed signal that may not appear on the server, for example, a <see cref="SignalEntity"/> that has been
+        /// created but not saved, a signal from another server, or the modified representation of an entity already persisted.</param>
+        /// <param name="timeout">The query timeout; if not specified, the query will run until completion.</param>
+        /// <param name="variables">Values for any free variables that appear in <paramref name="query"/>.</param>
+        /// <param name="trace">Enable detailed (server-side) query tracing.</param>
+        /// <param name="cancellationToken">Token through which the operation can be cancelled.</param>
+        /// <returns>A structured result set or syntax/execution error information.</returns>
+        public async Task<QueryResultPart> TryQueryAsync(
+            string query,
+            DateTime? rangeStartUtc = null,
+            DateTime? rangeEndUtc = null,
+            SignalExpressionPart signal = null,
+            SignalEntity unsavedSignal = null,
+            TimeSpan? timeout = null,
+            Dictionary<string, object> variables = null,
+            bool trace = false,
+            CancellationToken cancellationToken = default)
+        {
+            MakeParameters(query, rangeStartUtc, rangeEndUtc, signal, unsavedSignal, timeout, variables, trace, out var body, out var parameters);
+            return await GroupTryPostAsync<EvaluationContextPart, QueryResultPart>("Query", body, parameters, cancellationToken).ConfigureAwait(false);
+        }
+                
         /// <summary>
         /// Execute an SQL query and retrieve the result set as a structured <see cref="QueryResultPart"/>.
         /// </summary>

--- a/src/Seq.Api/ResourceGroups/MetricsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/MetricsResourceGroup.cs
@@ -37,8 +37,8 @@ public class MetricsResourceGroup : ApiResourceGroup
     /// <param name="filter">A strict Seq filter expression to match (text expressions must be in double quotes). To
     /// convert a "fuzzy" filter into a strict one the way the Seq UI does, use <see cref="ExpressionsResourceGroup.ToStrictAsync"/>.</param>
     /// <param name="count">The number of definitions to retrieve. If not specified will default to 30.</param>
-    /// <param name="rangeStartUtc">The earliest timestamp from which to include events in the query result.</param>
-    /// <param name="rangeEndUtc">The exclusive latest timestamp to which events are included in the query result. The default is the current time.</param>
+    /// <param name="rangeStartUtc">The earliest timestamp from which to include definitions in the query result.</param>
+    /// <param name="rangeEndUtc">The exclusive latest timestamp to which definitions are included in the query result. The default is the current time.</param>
     /// <param name="timeout">The query timeout; if not specified, the query will run until completion.</param>
     /// <param name="variables">Values for any free variables that appear in <paramref name="filter"/>.</param>
     /// <param name="trace">Enable detailed (server-side) query tracing.</param>
@@ -61,13 +61,13 @@ public class MetricsResourceGroup : ApiResourceGroup
     }
 
     /// <summary>
-    /// Retrieve information about the labels available for filtering samples matching a set of search criteria.
+    /// Retrieve information about the dimensions available for filtering samples matching a set of search criteria.
     /// </summary>
-    /// <param name="count">The number of definitions to retrieve. If not specified will default to 30.</param>
+    /// <param name="count">The number of dimensions to retrieve. If not specified will default to 30.</param>
     /// <param name="metric">Optionally, the name of a metric to limit dimension search to. By default, dimensions
     /// for all metrics are returned.</param>
-    /// <param name="rangeStartUtc">The earliest timestamp from which to include events in the query result.</param>
-    /// <param name="rangeEndUtc">The exclusive latest timestamp to which events are included in the query result. The default is the current time.</param>
+    /// <param name="rangeStartUtc">The earliest timestamp from which to include dimensions in the query result.</param>
+    /// <param name="rangeEndUtc">The exclusive latest timestamp to which dimensions are included in the query result. The default is the current time.</param>
     /// <param name="timeout">The query timeout; if not specified, the query will run until completion.</param>
     /// <param name="trace">Enable detailed (server-side) query tracing.</param>
     /// <param name="cancellationToken">Token through which the operation can be cancelled.</param>
@@ -86,6 +86,33 @@ public class MetricsResourceGroup : ApiResourceGroup
             parameters.Add(nameof(metric), metric);
         var body = new EvaluationContextPart();
         return await GroupPostAsync<EvaluationContextPart, List<MetricDimensionPart>>("Dimensions", body, parameters, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Retrieve the top <paramref name="count"/> values associated with the metric dimension <paramref name="accessor"/>.
+    /// </summary>
+    /// <param name="accessor">The dimension's accessor. This is generally a simple property path (<c>cluster.node.name</c>) but can
+    /// use explict root namespaces and indexer notation (<c>@Resource.cluster['node name']</c>) if necessary.</param>
+    /// <param name="count">The number of values to retrieve. If not specified will default to 30.</param>
+    /// <param name="rangeStartUtc">The earliest timestamp from which to include values in the query result.</param>
+    /// <param name="rangeEndUtc">The exclusive latest timestamp to which values are included in the query result. The default is the current time.</param>
+    /// <param name="timeout">The query timeout; if not specified, the query will run until completion.</param>
+    /// <param name="trace">Enable detailed (server-side) query tracing.</param>
+    /// <param name="cancellationToken">Token through which the operation can be cancelled.</param>
+    /// <returns>A structured result set.</returns>
+    public async Task<List<object>> ListDimensionValuesAsync(
+        string accessor,
+        int count = 30,
+        DateTime? rangeStartUtc = null,
+        DateTime? rangeEndUtc = null,
+        TimeSpan? timeout = null,
+        bool trace = false,
+        CancellationToken cancellationToken = default)
+    {
+        var parameters = MakeParameters(null, null, count, rangeStartUtc, rangeEndUtc, timeout, trace);
+        parameters.Add(nameof(accessor), accessor);
+        var body = new EvaluationContextPart();
+        return await GroupPostAsync<EvaluationContextPart, List<object>>("DimensionValues", body, parameters, cancellationToken).ConfigureAwait(false);
     }
 
     static Dictionary<string, object> MakeParameters(List<string> groups, string filter, int count, DateTime? rangeStartUtc, DateTime? rangeEndUtc, TimeSpan? timeout, bool trace)

--- a/src/Seq.Api/ResourceGroups/QueriesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/QueriesResourceGroup.cs
@@ -17,17 +17,17 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model;
-using Seq.Api.Model.SqlQueries;
+using Seq.Api.Model.Queries;
 using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
     /// <summary>
-    /// Perform operations on saved SQL queries.
+    /// Perform operations on saved queries.
     /// </summary>
-    public class SqlQueriesResourceGroup : ApiResourceGroup
+    public class QueriesResourceGroup : ApiResourceGroup
     {
-        internal SqlQueriesResourceGroup(ILoadResourceGroup connection)
+        internal QueriesResourceGroup(ILoadResourceGroup connection)
             : base("SqlQueries", connection)
         {
         }
@@ -38,10 +38,10 @@ namespace Seq.Api.ResourceGroups
         /// <param name="id">The id of the query.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>The query.</returns>
-        public async Task<SqlQueryEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<QueryEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
-            return await GroupGetAsync<SqlQueryEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+            return await GroupGetAsync<QueryEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -52,10 +52,10 @@ namespace Seq.Api.ResourceGroups
         /// <param name="shared">If <c>true</c>, shared queries will be included in the result.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A list containing matching queries.</returns>
-        public async Task<List<SqlQueryEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
+        public async Task<List<QueryEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, { "shared", shared } };
-            return await GroupListAsync<SqlQueryEntity>("Items", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupListAsync<QueryEntity>("Items", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -63,9 +63,9 @@ namespace Seq.Api.ResourceGroups
         /// </summary>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>The unsaved query.</returns>
-        public async Task<SqlQueryEntity> TemplateAsync(CancellationToken cancellationToken = default)
+        public async Task<QueryEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await GroupGetAsync<SqlQueryEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupGetAsync<QueryEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -74,9 +74,9 @@ namespace Seq.Api.ResourceGroups
         /// <param name="entity">The query to add.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>The query, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
-        public async Task<SqlQueryEntity> AddAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
+        public async Task<QueryEntity> AddAsync(QueryEntity entity, CancellationToken cancellationToken = default)
         {
-            return await GroupCreateAsync<SqlQueryEntity, SqlQueryEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<QueryEntity, QueryEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Seq.Api.ResourceGroups
         /// <param name="entity">The query to remove.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A task indicating completion.</returns>
-        public async Task RemoveAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
+        public async Task RemoveAsync(QueryEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -96,7 +96,7 @@ namespace Seq.Api.ResourceGroups
         /// <param name="entity">The query to update.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A task indicating completion.</returns>
-        public async Task UpdateAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
+        public async Task UpdateAsync(QueryEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -180,9 +180,9 @@ namespace Seq.Api
         public SignalsResourceGroup Signals => new(this);
 
         /// <summary>
-        /// Perform operations on saved SQL queries.
+        /// Perform operations on saved queries.
         /// </summary>
-        public SqlQueriesResourceGroup SqlQueries => new(this);
+        public QueriesResourceGroup Queries => new(this);
 
         /// <summary>
         /// Perform operations on known available Seq versions.


### PR DESCRIPTION
The `/api/data` endpoint returns 400 on syntax errors; this prevents interactive clients properly reporting full error information.